### PR TITLE
Wait for head SHA on pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,13 @@ This actions depends on `docker pull` and `docker image inspect` command.
 
 ### Inputs
 
-| Name                | Default      | Description                           |
-| ------------------- | ------------ | ------------------------------------- |
-| `tags`              | (required)   | Docker image tags                     |
-| `expected-revision` | `github.sha` | Expected Git revision of Docker image |
-| `timeout-seconds`   | 600          | Timeout                               |
-| `polling-seconds`   | 5            | Polling interval                      |
+| Name                | Default     | Description                            |
+| ------------------- | ----------- | -------------------------------------- |
+| `tags`              | (required)  | Docker image tags                      |
+| `expected-revision` | (see below) | Expected Git revisions of Docker image |
+| `timeout-seconds`   | 600         | Timeout                                |
+| `polling-seconds`   | 5           | Polling interval                       |
+
+By default, this action waits until the revision is `github.sha` or `github.event.pull_request.head.sha`.
+Since [docker/metadata-action@v4.1.0](https://github.com/docker/metadata-action/releases/tag/v4.1.0),
+it generates the head sha on pull request event (see also [the issue](https://github.com/docker/metadata-action/issues/206)).

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,7 @@ inputs:
   expected-revision:
     description: expected Git revisions (multi-line string)
     required: true
-    default: |
+    default: |-
       ${{ github.sha }}
       ${{ github.event.pull_request.head.sha }}
   timeout-seconds:

--- a/action.yaml
+++ b/action.yaml
@@ -6,9 +6,11 @@ inputs:
     description: Docker tags (multi-line string)
     required: true
   expected-revision:
-    description: expected Git revision
+    description: expected Git revisions (multi-line string)
     required: true
-    default: ${{ github.sha }}
+    default: |
+      ${{ github.sha }}
+      ${{ github.event.pull_request.head.sha }}
   timeout-seconds:
     description: timeout in seconds
     required: true

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { run } from './run'
 const main = async (): Promise<void> => {
   await run({
     tags: core.getMultilineInput('tags', { required: true }),
-    expectedRevision: core.getInput('expected-revision', { required: true }),
+    expectedRevisions: core.getMultilineInput('expected-revision', { required: true }),
     timeoutSeconds: parseInt(core.getInput('timeout-seconds', { required: true })),
     pollingSeconds: parseInt(core.getInput('polling-seconds', { required: true })),
   })

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,7 +3,7 @@ import * as exec from '@actions/exec'
 
 type Inputs = {
   tags: string[]
-  expectedRevision: string
+  expectedRevisions: string[]
   timeoutSeconds: number
   pollingSeconds: number
 }
@@ -22,9 +22,10 @@ export const run = async (inputs: Inputs): Promise<void> => {
 const checkIfDockerImageRevisionIsExpected = async (inputs: Inputs): Promise<boolean> => {
   for (const tag of inputs.tags) {
     const revision = await getDockerImageRevision(tag)
-    if (revision !== inputs.expectedRevision) {
-      return false
+    if (revision && inputs.expectedRevisions.includes(revision)) {
+      continue
     }
+    return false
   }
   return true
 }


### PR DESCRIPTION
## Problem to solve
Since [docker/metadata-action@v4.1.0](https://github.com/docker/metadata-action/releases/tag/v4.1.0), it generates the head sha on pull request event.
See also https://github.com/docker/metadata-action/issues/206.

## How to solve
By default, this action will wait until the revision is `github.sha` or `github.event.pull_request.head.sha`.
